### PR TITLE
Make client websocket aware of the used protocol (http/https -> ws/wss)

### DIFF
--- a/src/client/networking.js
+++ b/src/client/networking.js
@@ -6,7 +6,8 @@ import { processGameUpdate } from './state';
 
 const Constants = require('../shared/constants');
 
-const socket = io(`ws://${window.location.host}`, { reconnection: false });
+const socketProtocol = (window.location.protocol === 'https') ? 'wss' : 'ws';
+const socket = io(`${socketProtocol}://${window.location.host}`, { reconnection: false });
 const connectedPromise = new Promise(resolve => {
   socket.on('connect', () => {
     console.log('Connected to server!');


### PR DESCRIPTION
The websocket has to use the appropriate protocol, or else it can come to CORS errors.

Fixes the second part of #4.