### PR TITLE
🐛 Adding openssl-legacy-provider option to fix broken run time

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "webpack --config webpack.prod.js",
     "lint": "eslint --cache --ext .js,.jsx src/",
-    "develop": "cross-env NODE_ENV=development node src/server/server.js",
-    "start": "cross-env NODE_ENV=production node src/server/server.js",
+    "develop": "cross-env NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development node src/server/server.js",
+    "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=production node src/server/server.js",
     "test": "jest"
   },
   "author": "Victor Zhou",


### PR DESCRIPTION
Resolves the broken `npm run develop` when using node 17 and node 18

Fixes #40 